### PR TITLE
Score format update

### DIFF
--- a/cargame.py
+++ b/cargame.py
@@ -327,11 +327,11 @@ class Game:
             "FINAL SCORE ",
             self.score_font,
             (80, 80, 80),
-            self.SCREEN_WIDTH / 2 - 100,
+            self.SCREEN_WIDTH / 2 - 50,
             230,
         )
         self.message_display(
-            self.score, self.score_font, (80, 80, 80), self.SCREEN_WIDTH / 2 + 100, 230
+            self.score, self.score_font, (80, 80, 80), self.SCREEN_WIDTH / 2 + 150, 230
         )
 
         if not self.has_update_scores:

--- a/cargame.py
+++ b/cargame.py
@@ -351,6 +351,9 @@ class Game:
             if len(self.scores) > 5:
                 self.scores = self.scores[:5]
 
+            #formatting the scores
+            self.scores = self.pad_scores(self.scores)
+
             # Rewrites the high_scores file with the updated high scores
             with open("high_scores.txt", "w") as hs_file:
                 hs_file.write(" ".join([str(i) for i in self.scores]))
@@ -435,6 +438,19 @@ class Game:
 
         self.SCREEN.blit(img, (x, y))
 
+    # padding zeroes for high scores to have same digits for alignment
+    @staticmethod
+    def pad_scores(scores):
+        """
+        :param: scores : high scores in descending order
+        :type: list
+
+        :return: high scores in padded format
+        :type: list
+        """
+        length_of_highest_score = len(str(scores[0]))
+        scores_padded = [str(score).zfill(length_of_highest_score) for score in scores]
+        return scores_padded
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
### Addressed issues:
1. Final score display is not aligned centrally
    - Adjusted the width value in the final score display function
2. High scores are not padded with zeroes
    - Created new static method called pad_scores to padded the scores with zeroes in left to correct the alignment


### Testing:
* Final score and high scores alignment are validated for scores with lengths till 5 digits

